### PR TITLE
Add /usr/libexec/hal-droid/system/ to library search path.

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -31,9 +31,11 @@
 #if defined(__LP64__)
 #define HAL_LIBRARY_PATH1 "/system/lib64/hw"
 #define HAL_LIBRARY_PATH2 "/vendor/lib64/hw"
+#define HAL_LIBRARY_PATH3 "/usr/libexec/hal-droid/system/lib64/hw"
 #else
 #define HAL_LIBRARY_PATH1 "/system/lib/hw"
 #define HAL_LIBRARY_PATH2 "/vendor/lib/hw"
+#define HAL_LIBRARY_PATH3 "/usr/libexec/hal-droid/system/lib/hw"
 #endif
 
 /**
@@ -129,6 +131,11 @@ static int load(const char *id,
 static int hw_module_exists(char *path, size_t path_len, const char *name,
                             const char *subname)
 {
+    snprintf(path, path_len, "%s/%s.%s.so",
+             HAL_LIBRARY_PATH3, name, subname);
+    if (access(path, R_OK) == 0)
+        return 0;
+
     snprintf(path, path_len, "%s/%s.%s.so",
              HAL_LIBRARY_PATH2, name, subname);
     if (access(path, R_OK) == 0)


### PR DESCRIPTION
This allows for generic hybris tarballs as used for the current Oreo based watches.